### PR TITLE
chore: package.json fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "version": "1.2.4",
   "description": "discord-modals is a package that allows your bot of discord.js v13 & v14 to create the new awesome Discord Modals and interact with them.",
   "main": "index.js",
+  "files": [
+    "src",
+    "index.d.ts",
+    "index.js"
+  ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -22,11 +22,8 @@
     "discord-modals",
     "discord",
     "discord.js-modals",
-    "discord.js-forms"    
+    "discord.js-forms"
   ],
-  "dependencies": {
-    "discord.js": "^13.6.0"
-  },
   "types": "index.d.ts",
   "author": "『𝑴𝒂𝒕𝒆𝒐ᵗᵉᵐ』#9999",
   "license": "MIT",
@@ -37,5 +34,11 @@
     "type": "git",
     "url": "https://github.com/Mateo-tem/discord-modals.git"
   },
-  "homepage": "https://github.com/Mateo-tem/discord-modals#readme"
+  "homepage": "https://github.com/Mateo-tem/discord-modals#readme",
+  "peerDependencies": {
+    "discord.js": "*"
+  },
+  "devDependencies": {
+    "discord.js": "^13.6.0"
+  }
 }


### PR DESCRIPTION
- Add `files` field; this makes sure you only publish to npm the necessary files (daf808d)
- Move `discord.js` to peerDependencies and devDependencies (353cf93; read below)
- Add `node_modules` to `.gitignore` (2fcd81f)

----
Even though `discord-modals` functionality is quite simple, its **install size** is over 6MB ([packagephobia](https://packagephobia.com/result?p=discord-modals)); this is because it has `discord.js` on its dependencies. For reference, [check discord.js' install size](https://packagephobia.com/result?p=discord.js) (values are a rough approximation).

Moving it to `peerDependencies` will make sure the package just grabs any `discord.js` dependency on the user's project.