### PR TITLE
fix: remove wrong typings, smh

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -133,32 +133,12 @@ export class ModalSubmitInteraction extends Interaction {
 
   customId: string;
   fields: ModalSubmitField[];
-  deferred: boolean;
-  ephemeral: boolean | null;
-  replied: boolean;
-  id: Snowflake;
-  applicationId: Snowflake;
-  channelId: Snowflake;
-  user: User;
-  member: GuildMember;
-  memberPermissions: Permissions;
-  locale: string;
-  guildLocale: string;
-  message: Message;
   webhook: InteractionWebhook;
 
   getTextInputValue(customId: string): string;
   getField(customId: string): ModalSubmitField;
   isFromMessage(): boolean;
   isRepliable(): boolean;
-  inGuild(): boolean;
-  inCachedGuild(): boolean;
-  inRawGuild(): boolean;
-  deferReply(): Promise<void>;
-  reply(): Promise<void>;
-  fetchReply(): Promise<void>;
-  deleteReply(): Promise<void>;
-  followUp(): Promise<void>;
 }
 
 export function showModal(


### PR DESCRIPTION
Si `ModalSubmitInteraction` hereda de `Interaction`, esto significa que hereda los mismos métodos que la clase base, y es redundante re-definirlos.

De paso, estás redefiniéndolos mal o a medias. El método `#reply`, en tu declaración, no admite ningún argumento; ¿cómo se supone que le pase una respuesta?

Y por último, los métodos `#inGuild` y similares no solo devuelven un valor booleano, sino que funcionan como un type guard. [Véase la declaración de discord.js](https://github.com/discordjs/discord.js/blob/988a51b7641f8b33cc9387664605ddc02134859d/typings/index.d.ts#L346-L348).
