### PR TITLE
Add init() + init() typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,6 +22,8 @@ import {
 
 export default function (client: Client): void;
 
+export function init(client: Client): void;
+
 export enum TextInputStyles {
   SHORT = 1,
   LONG,

--- a/index.js
+++ b/index.js
@@ -59,6 +59,9 @@ if (discordjsVersion.includes("v13")) {
   module.exports.SnowflakeUtil = require("./src/util/SnowflakeUtil");
 }
 
+//Easier for typescript
+module.exports.init = this;
+
 /* Powered by:
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓


### PR DESCRIPTION
**This ONLY adds the `Modals.init()` function**

This would be easier for typescript users because then they can use

```diff
- import Modals from "discord-modals";
+ import { init } from "discord-modals";
```

Not having the `init()` function causes typescript to compile it as

```
Modals.default()
```