### PR TITLE
[Fix] `ephemeral` flag not working in interaction reply

### DIFF
--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -33,6 +33,8 @@ class InteractionResponses {
 
     const { data, files } = await messagePayload.resolveData().resolveFiles();
 
+    data.flags = options.ephemeral ? MessageFlags.FLAGS.EPHEMERAL : undefined;
+
     await this.client.api.interactions(this.id, this.token).callback.post({
       data: {
         type: InteractionResponseTypes.CHANNEL_MESSAGE_WITH_SOURCE,

--- a/src/v14/interfaces/InteractionResponses.js
+++ b/src/v14/interfaces/InteractionResponses.js
@@ -36,6 +36,8 @@ class InteractionResponses {
     else messagePayload = MessagePayload.create(this, options);
 
     const { body: data, files } = await messagePayload.resolveBody().resolveFiles();
+    
+    data.flags = options.ephemeral ? MessageFlags.FLAGS.EPHEMERAL : undefined;
 
     await this.client.rest.post(Routes.interactionCallback(this.id, this.token), {
       body: {


### PR DESCRIPTION
Previously the `InteractionResponses.reply` function did not handle the ephemeral flag correctly. The `data.flags` property was always being set to `undefined` regardless on if `ephemeral: true` was passed or not. These changes simply copy over the ephemeral check from `InteractionResponses.deferReply` to correctly support ephemeral responses in replies. Tested on Discord.JS v13.6.0 with no issues