### PR TITLE
fix: ephemeral flag not working in InteractionResponses.js v14

### DIFF
--- a/src/v14/interfaces/InteractionResponses.js
+++ b/src/v14/interfaces/InteractionResponses.js
@@ -48,7 +48,7 @@ class InteractionResponses {
       .resolveBody()
       .resolveFiles();
 
-    data.flags = options.ephemeral ? MessageFlags.FLAGS.EPHEMERAL : undefined;
+    data.flags = options.ephemeral ? MessageFlags.Ephemeral : undefined;
 
     await this.client.rest.post(
       Routes.interactionCallback(this.id, this.token),


### PR DESCRIPTION
I've just seen an error on [Stack Overflow](https://stackoverflow.com/questions/73267269/discord-js-typeerror-cannot-read-properties-of-undefined-reading-ephemeral) where if you add the `ephemeral: true` option to your `reply()` you receive a `TypeError: Cannot read properties of undefined (reading 'EPHEMERAL')`. It's caused by a non-existing property on `MessageFlags` (`MessageFlags.FLAGS`) in [`InteractionResponses.js`](https://github.com/Mateo-tem/discord-modals/blob/master/src/v14/interfaces/InteractionResponses.js#L51). This pull request fixes the error.

It seems someone also opened an issue for this. Fixes #110 